### PR TITLE
Implement Settings tab viewer

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@
 | 6 | Wiki | - | placeholder | 미구현 |
 | 7 | Security | - | placeholder | 미구현 |
 | 8 | Insights | - | placeholder | 미구현 |
-| 9 | Settings | - | placeholder | 미구현 |
+| 9 | Settings | ✅ | settings.rs | 일반설정, 브랜치 보호, Collaborators (read-only) |
 
 ### 완료된 기반 기능
 
@@ -136,10 +136,10 @@
 
 ## Phase 8 — Settings 탭
 
-- [ ] Repository API (read-only 우선)
-- [ ] 일반 설정 (이름, description, visibility)
-- [ ] 브랜치 보호 규칙 보기
-- [ ] Collaborators 목록
+- [x] Repository API (read-only 우선)
+- [x] 일반 설정 (이름, description, visibility)
+- [x] 브랜치 보호 규칙 보기
+- [x] Collaborators 목록
 - [ ] Webhooks 목록
 - [ ] Deploy keys
 

--- a/crates/ghtui-api/src/endpoints/mod.rs
+++ b/crates/ghtui-api/src/endpoints/mod.rs
@@ -3,3 +3,4 @@ pub mod issues;
 pub mod notifications;
 pub mod pulls;
 pub mod search;
+pub mod settings;

--- a/crates/ghtui-api/src/endpoints/settings.rs
+++ b/crates/ghtui-api/src/endpoints/settings.rs
@@ -1,0 +1,88 @@
+use ghtui_core::types::common::RepoId;
+use ghtui_core::types::settings::{BranchProtection, Collaborator, Repository};
+
+use crate::client::GithubClient;
+use crate::error::ApiError;
+
+impl GithubClient {
+    pub async fn get_repo(&self, repo: &RepoId) -> Result<Repository, ApiError> {
+        let path = format!("/repos/{}/{}", repo.owner, repo.name);
+        let body = self.get(&path).await?;
+        let repository: Repository = serde_json::from_str(&body)?;
+        Ok(repository)
+    }
+
+    pub async fn list_branch_protections(
+        &self,
+        repo: &RepoId,
+    ) -> Result<Vec<BranchProtection>, ApiError> {
+        let path = format!(
+            "/repos/{}/{}/branches?protected=true",
+            repo.owner, repo.name
+        );
+        let body = self.get(&path).await?;
+
+        // GitHub returns branches, we extract protection rules
+        let branches: Vec<serde_json::Value> = serde_json::from_str(&body)?;
+        let mut protections = Vec::new();
+
+        for branch in branches {
+            if branch.get("protected").and_then(|v| v.as_bool()) == Some(true) {
+                let name = branch
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+
+                // Try to get detailed protection rules
+                let detail_path = format!(
+                    "/repos/{}/{}/branches/{}/protection",
+                    repo.owner, repo.name, name
+                );
+                let protection = match self.get(&detail_path).await {
+                    Ok(detail_body) => {
+                        let detail: serde_json::Value =
+                            serde_json::from_str(&detail_body).unwrap_or_default();
+
+                        let required_status_checks = detail
+                            .get("required_status_checks")
+                            .and_then(|v| serde_json::from_value(v.clone()).ok());
+                        let enforce_admins = detail
+                            .get("enforce_admins")
+                            .and_then(|v| serde_json::from_value(v.clone()).ok());
+                        let required_pull_request_reviews = detail
+                            .get("required_pull_request_reviews")
+                            .and_then(|v| serde_json::from_value(v.clone()).ok());
+
+                        BranchProtection {
+                            pattern: name,
+                            required_status_checks,
+                            enforce_admins,
+                            required_pull_request_reviews,
+                        }
+                    }
+                    Err(_) => BranchProtection {
+                        pattern: name,
+                        required_status_checks: None,
+                        enforce_admins: None,
+                        required_pull_request_reviews: None,
+                    },
+                };
+
+                protections.push(protection);
+            }
+        }
+
+        Ok(protections)
+    }
+
+    pub async fn list_collaborators(&self, repo: &RepoId) -> Result<Vec<Collaborator>, ApiError> {
+        let path = format!(
+            "/repos/{}/{}/collaborators?per_page=30",
+            repo.owner, repo.name
+        );
+        let body = self.get(&path).await?;
+        let collaborators: Vec<Collaborator> = serde_json::from_str(&body)?;
+        Ok(collaborators)
+    }
+}

--- a/crates/ghtui-core/src/command.rs
+++ b/crates/ghtui-core/src/command.rs
@@ -42,6 +42,11 @@ pub enum Command {
     // Search
     Search(String, SearchKind, u32),
 
+    // Settings
+    FetchRepoSettings(RepoId),
+    FetchBranchProtections(RepoId),
+    FetchCollaborators(RepoId),
+
     // Utility
     OpenInBrowser(String),
     SetClipboard(String),

--- a/crates/ghtui-core/src/message.rs
+++ b/crates/ghtui-core/src/message.rs
@@ -45,6 +45,11 @@ pub enum Message {
     // Search
     SearchResults(SearchResultSet),
 
+    // Settings
+    SettingsRepoLoaded(Box<settings::Repository>),
+    SettingsBranchProtectionsLoaded(Vec<settings::BranchProtection>),
+    SettingsCollaboratorsLoaded(Vec<settings::Collaborator>),
+
     // UI
     InputChanged(String),
     ListSelect(usize),

--- a/crates/ghtui-core/src/state/mod.rs
+++ b/crates/ghtui-core/src/state/mod.rs
@@ -3,6 +3,7 @@ pub mod issue;
 pub mod notification;
 pub mod pr;
 pub mod search;
+pub mod settings;
 
 use std::collections::{HashSet, VecDeque};
 
@@ -17,6 +18,7 @@ pub use issue::*;
 pub use notification::*;
 pub use pr::*;
 pub use search::*;
+pub use settings::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum InputMode {
@@ -54,6 +56,7 @@ pub struct AppState {
     pub action_detail: Option<ActionDetailState>,
     pub notifications: Option<NotificationListState>,
     pub search: Option<SearchViewState>,
+    pub settings: Option<SettingsState>,
 
     // Cross-cutting
     pub current_repo: Option<RepoId>,
@@ -92,6 +95,7 @@ impl AppState {
             action_detail: None,
             notifications: None,
             search: None,
+            settings: None,
             current_repo: repo,
             loading: HashSet::new(),
             toasts: VecDeque::new(),

--- a/crates/ghtui-core/src/state/settings.rs
+++ b/crates/ghtui-core/src/state/settings.rs
@@ -1,0 +1,26 @@
+use crate::types::settings::{BranchProtection, Collaborator, Repository};
+
+#[derive(Debug)]
+pub struct SettingsState {
+    pub repo: Repository,
+    pub branch_protections: Vec<BranchProtection>,
+    pub collaborators: Vec<Collaborator>,
+    pub scroll: usize,
+    pub tab: usize, // 0=General, 1=Branch Protection, 2=Collaborators
+}
+
+impl SettingsState {
+    pub fn new(repo: Repository) -> Self {
+        Self {
+            repo,
+            branch_protections: Vec::new(),
+            collaborators: Vec::new(),
+            scroll: 0,
+            tab: 0,
+        }
+    }
+
+    pub fn tab_count(&self) -> usize {
+        3
+    }
+}

--- a/crates/ghtui-core/src/types/mod.rs
+++ b/crates/ghtui-core/src/types/mod.rs
@@ -4,6 +4,7 @@ pub mod issue;
 pub mod notification;
 pub mod pull_request;
 pub mod search;
+pub mod settings;
 
 pub use actions::*;
 pub use common::*;
@@ -11,3 +12,4 @@ pub use issue::*;
 pub use notification::*;
 pub use pull_request::*;
 pub use search::*;
+pub use settings::*;

--- a/crates/ghtui-core/src/types/settings.rs
+++ b/crates/ghtui-core/src/types/settings.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+
+use super::common::User;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Repository {
+    pub name: String,
+    pub full_name: String,
+    pub description: Option<String>,
+    pub private: bool,
+    pub fork: bool,
+    pub archived: bool,
+    pub disabled: bool,
+    pub visibility: Option<String>,
+    pub default_branch: String,
+    pub language: Option<String>,
+    pub stargazers_count: u64,
+    pub forks_count: u64,
+    pub open_issues_count: u64,
+    pub watchers_count: u64,
+    pub size: u64,
+    pub has_issues: bool,
+    pub has_projects: bool,
+    pub has_wiki: bool,
+    pub has_discussions: Option<bool>,
+    pub allow_forking: Option<bool>,
+    pub topics: Option<Vec<String>>,
+    pub license: Option<License>,
+    pub owner: User,
+    pub html_url: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub pushed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct License {
+    pub key: String,
+    pub name: String,
+    pub spdx_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchProtection {
+    pub pattern: String,
+    #[serde(default)]
+    pub required_status_checks: Option<RequiredStatusChecks>,
+    #[serde(default)]
+    pub enforce_admins: Option<EnforceAdmins>,
+    #[serde(default)]
+    pub required_pull_request_reviews: Option<RequiredPullRequestReviews>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequiredStatusChecks {
+    pub strict: bool,
+    #[serde(default)]
+    pub contexts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnforceAdmins {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequiredPullRequestReviews {
+    #[serde(default)]
+    pub required_approving_review_count: Option<u32>,
+    #[serde(default)]
+    pub dismiss_stale_reviews: bool,
+    #[serde(default)]
+    pub require_code_owner_reviews: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Collaborator {
+    pub login: String,
+    pub avatar_url: String,
+    #[serde(default)]
+    pub role_name: Option<String>,
+    pub permissions: Option<CollaboratorPermissions>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollaboratorPermissions {
+    #[serde(default)]
+    pub admin: bool,
+    #[serde(default)]
+    pub maintain: bool,
+    #[serde(default)]
+    pub push: bool,
+    #[serde(default)]
+    pub triage: bool,
+    #[serde(default)]
+    pub pull: bool,
+}

--- a/crates/ghtui/src/command_executor.rs
+++ b/crates/ghtui/src/command_executor.rs
@@ -127,6 +127,22 @@ pub async fn execute(client: &GithubClient, cmd: Command) -> Message {
             Err(e) => Message::Error(e.into()),
         },
 
+        // Settings
+        Command::FetchRepoSettings(repo) => match client.get_repo(&repo).await {
+            Ok(repository) => Message::SettingsRepoLoaded(Box::new(repository)),
+            Err(e) => Message::Error(e.into()),
+        },
+        Command::FetchBranchProtections(repo) => {
+            match client.list_branch_protections(&repo).await {
+                Ok(protections) => Message::SettingsBranchProtectionsLoaded(protections),
+                Err(e) => Message::Error(e.into()),
+            }
+        }
+        Command::FetchCollaborators(repo) => match client.list_collaborators(&repo).await {
+            Ok(collaborators) => Message::SettingsCollaboratorsLoaded(collaborators),
+            Err(e) => Message::Error(e.into()),
+        },
+
         // Utility
         Command::OpenInBrowser(url) => {
             let _ = open::that(&url);

--- a/crates/ghtui/src/keybindings.rs
+++ b/crates/ghtui/src/keybindings.rs
@@ -64,6 +64,7 @@ fn handle_normal_mode(key: KeyEvent, state: &AppState) -> Option<Message> {
             | Route::IssueDetail { .. }
             | Route::ActionDetail { .. }
             | Route::JobLog { .. }
+            | Route::Settings { .. }
     );
     if !in_detail {
         match key.code {
@@ -88,6 +89,7 @@ fn handle_normal_mode(key: KeyEvent, state: &AppState) -> Option<Message> {
     match &state.route {
         Route::PrDetail { .. } => handle_pr_detail_keys(key),
         Route::IssueDetail { .. } => handle_issue_detail_keys(key),
+        Route::Settings { .. } => handle_settings_keys(key),
         _ => handle_list_keys(key),
     }
 }
@@ -120,6 +122,16 @@ fn handle_list_keys(key: KeyEvent) -> Option<Message> {
         KeyCode::Char('k') | KeyCode::Up => Some(Message::ListSelect(usize::MAX)),
         KeyCode::Enter => Some(Message::ListSelect(0)),
         KeyCode::Char('r') => Some(Message::Tick), // refresh
+        _ => None,
+    }
+}
+
+fn handle_settings_keys(key: KeyEvent) -> Option<Message> {
+    match key.code {
+        KeyCode::Tab => Some(Message::TabChanged(1)),
+        KeyCode::BackTab => Some(Message::TabChanged(usize::MAX)),
+        KeyCode::Char('j') | KeyCode::Down => Some(Message::ListSelect(1)),
+        KeyCode::Char('k') | KeyCode::Up => Some(Message::ListSelect(usize::MAX)),
         _ => None,
     }
 }

--- a/crates/ghtui/src/update/mod.rs
+++ b/crates/ghtui/src/update/mod.rs
@@ -32,6 +32,7 @@ pub fn update(state: &mut AppState, msg: Message) -> Vec<Command> {
             state.action_detail = None;
             state.notifications = None;
             state.search = None;
+            state.settings = None;
             // Refresh current view
             refresh_current_view(state)
         }
@@ -157,6 +158,37 @@ pub fn update(state: &mut AppState, msg: Message) -> Vec<Command> {
             vec![]
         }
 
+        // Settings
+        Message::SettingsRepoLoaded(repo) => {
+            state.loading.remove("settings");
+            state.settings = Some(SettingsState::new(*repo));
+            // Also fetch branch protections and collaborators
+            if let Some(ref repo_id) = state.current_repo {
+                state.loading.insert("branch_protections".to_string());
+                state.loading.insert("collaborators".to_string());
+                vec![
+                    Command::FetchBranchProtections(repo_id.clone()),
+                    Command::FetchCollaborators(repo_id.clone()),
+                ]
+            } else {
+                vec![]
+            }
+        }
+        Message::SettingsBranchProtectionsLoaded(protections) => {
+            state.loading.remove("branch_protections");
+            if let Some(ref mut settings) = state.settings {
+                settings.branch_protections = protections;
+            }
+            vec![]
+        }
+        Message::SettingsCollaboratorsLoaded(collaborators) => {
+            state.loading.remove("collaborators");
+            if let Some(ref mut settings) = state.settings {
+                settings.collaborators = collaborators;
+            }
+            vec![]
+        }
+
         // UI
         Message::InputChanged(text) => {
             if text == "\x08" {
@@ -183,7 +215,16 @@ pub fn update(state: &mut AppState, msg: Message) -> Vec<Command> {
             vec![]
         }
         Message::TabChanged(delta) => {
-            if let Some(ref mut detail) = state.pr_detail {
+            if matches!(state.route, Route::Settings { .. }) {
+                if let Some(ref mut settings) = state.settings {
+                    let max = settings.tab_count().saturating_sub(1);
+                    if delta == usize::MAX {
+                        settings.tab = settings.tab.saturating_sub(1);
+                    } else {
+                        settings.tab = (settings.tab + delta).min(max);
+                    }
+                }
+            } else if let Some(ref mut detail) = state.pr_detail {
                 if delta == usize::MAX {
                     detail.tab = detail.tab.saturating_sub(1);
                 } else {
@@ -308,7 +349,10 @@ fn handle_navigate(state: &mut AppState, route: Route) -> Vec<Command> {
         Route::Wiki { .. } => vec![],
         Route::Security { .. } => vec![],
         Route::Insights { .. } => vec![],
-        Route::Settings { .. } => vec![],
+        Route::Settings { repo } => {
+            state.loading.insert("settings".to_string());
+            vec![Command::FetchRepoSettings(repo.clone())]
+        }
         Route::Dashboard => vec![],
     };
 
@@ -419,6 +463,15 @@ fn handle_list_select(state: &mut AppState, delta: usize) {
                     list.select_prev();
                 } else if delta > 0 {
                     list.select_next();
+                }
+            }
+        }
+        Route::Settings { .. } => {
+            if let Some(ref mut settings) = state.settings {
+                if delta == usize::MAX {
+                    settings.scroll = settings.scroll.saturating_sub(1);
+                } else if delta > 0 {
+                    settings.scroll += 1;
                 }
             }
         }

--- a/crates/ghtui/src/view.rs
+++ b/crates/ghtui/src/view.rs
@@ -77,13 +77,7 @@ pub fn render(frame: &mut Frame, state: &AppState, _tick: usize) {
             "Insights",
             "Contributors, traffic, commits, and code frequency",
         ),
-        Route::Settings { .. } => views::placeholder::render(
-            frame,
-            state,
-            content_area,
-            "Settings",
-            "Repository settings and configuration",
-        ),
+        Route::Settings { .. } => views::settings::render(frame, state, content_area),
         Route::Search { .. } => views::placeholder::render(
             frame,
             state,

--- a/crates/ghtui/src/views/mod.rs
+++ b/crates/ghtui/src/views/mod.rs
@@ -9,3 +9,4 @@ pub mod notifications;
 pub mod placeholder;
 pub mod pr_detail;
 pub mod pr_list;
+pub mod settings;

--- a/crates/ghtui/src/views/settings.rs
+++ b/crates/ghtui/src/views/settings.rs
@@ -1,0 +1,417 @@
+use ghtui_core::AppState;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Tabs, Wrap};
+
+pub fn render(frame: &mut Frame, state: &AppState, area: Rect) {
+    let theme = &state.theme;
+
+    if state.is_loading("settings") {
+        let spinner = ghtui_widgets::Spinner::new(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as usize
+                / 100,
+        );
+        let paragraph = Paragraph::new(Line::from(spinner.span()))
+            .style(theme.text())
+            .block(
+                Block::default()
+                    .title(" Settings ")
+                    .borders(Borders::ALL)
+                    .border_style(theme.border_style()),
+            );
+        frame.render_widget(paragraph, area);
+        return;
+    }
+
+    let Some(ref settings) = state.settings else {
+        let paragraph = Paragraph::new("No data").style(theme.text_dim()).block(
+            Block::default()
+                .title(" Settings ")
+                .borders(Borders::ALL)
+                .border_style(theme.border_style()),
+        );
+        frame.render_widget(paragraph, area);
+        return;
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(2), Constraint::Min(0)])
+        .split(area);
+
+    // Sub-tab bar
+    let tab_titles = vec!["General", "Branch Protection", "Collaborators"];
+    let tabs = Tabs::new(tab_titles)
+        .select(settings.tab)
+        .style(Style::default().fg(theme.fg_muted))
+        .highlight_style(
+            Style::default()
+                .fg(theme.tab_active_fg)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        )
+        .divider(" │ ")
+        .block(
+            Block::default()
+                .borders(Borders::BOTTOM)
+                .border_style(theme.border_style()),
+        );
+    frame.render_widget(tabs, chunks[0]);
+
+    match settings.tab {
+        0 => render_general(frame, state, chunks[1]),
+        1 => render_branch_protections(frame, state, chunks[1]),
+        2 => render_collaborators(frame, state, chunks[1]),
+        _ => {}
+    }
+}
+
+fn render_general(frame: &mut Frame, state: &AppState, area: Rect) {
+    let theme = &state.theme;
+    let settings = state.settings.as_ref().unwrap();
+    let repo = &settings.repo;
+
+    let label_style = Style::default().fg(theme.fg_muted);
+    let value_style = theme.text();
+    let accent_bold = Style::default()
+        .fg(theme.accent)
+        .add_modifier(Modifier::BOLD);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    lines.push(Line::raw(""));
+    lines.push(kv("Name", &repo.full_name, label_style, value_style));
+    lines.push(kv(
+        "Description",
+        repo.description.as_deref().unwrap_or("(none)"),
+        label_style,
+        value_style,
+    ));
+    lines.push(kv(
+        "Visibility",
+        repo.visibility
+            .as_deref()
+            .unwrap_or(if repo.private { "private" } else { "public" }),
+        label_style,
+        value_style,
+    ));
+    lines.push(kv(
+        "Default branch",
+        &repo.default_branch,
+        label_style,
+        value_style,
+    ));
+    lines.push(kv(
+        "Language",
+        repo.language.as_deref().unwrap_or("(none)"),
+        label_style,
+        value_style,
+    ));
+    lines.push(kv(
+        "License",
+        repo.license
+            .as_ref()
+            .map(|l| l.name.as_str())
+            .unwrap_or("(none)"),
+        label_style,
+        value_style,
+    ));
+    lines.push(Line::raw(""));
+
+    // Stats
+    lines.push(Line::styled("  Statistics".to_string(), accent_bold));
+    lines.push(kv(
+        "Stars",
+        &repo.stargazers_count.to_string(),
+        label_style,
+        value_style,
+    ));
+    lines.push(kv(
+        "Forks",
+        &repo.forks_count.to_string(),
+        label_style,
+        value_style,
+    ));
+    lines.push(kv(
+        "Open issues",
+        &repo.open_issues_count.to_string(),
+        label_style,
+        value_style,
+    ));
+    lines.push(kv(
+        "Watchers",
+        &repo.watchers_count.to_string(),
+        label_style,
+        value_style,
+    ));
+    lines.push(kv(
+        "Size",
+        &format!("{} KB", repo.size),
+        label_style,
+        value_style,
+    ));
+    lines.push(Line::raw(""));
+
+    // Features
+    lines.push(Line::styled("  Features".to_string(), accent_bold));
+    lines.push(flag("Issues", repo.has_issues, theme));
+    lines.push(flag("Projects", repo.has_projects, theme));
+    lines.push(flag("Wiki", repo.has_wiki, theme));
+    lines.push(flag(
+        "Discussions",
+        repo.has_discussions.unwrap_or(false),
+        theme,
+    ));
+    lines.push(flag(
+        "Allow forking",
+        repo.allow_forking.unwrap_or(false),
+        theme,
+    ));
+    lines.push(Line::raw(""));
+
+    // Flags
+    lines.push(Line::styled("  Status".to_string(), accent_bold));
+    lines.push(flag("Fork", repo.fork, theme));
+    lines.push(flag("Archived", repo.archived, theme));
+    lines.push(flag("Disabled", repo.disabled, theme));
+    lines.push(Line::raw(""));
+
+    // Topics
+    if let Some(ref topics) = repo.topics {
+        if !topics.is_empty() {
+            lines.push(Line::styled("  Topics".to_string(), accent_bold));
+            let topic_spans: Vec<Span> = topics
+                .iter()
+                .map(|t| Span::styled(format!(" {} ", t), Style::default().fg(theme.accent)))
+                .collect();
+            lines.push(Line::from(topic_spans));
+            lines.push(Line::raw(""));
+        }
+    }
+
+    // Dates
+    lines.push(Line::styled("  Dates".to_string(), accent_bold));
+    lines.push(kv("Created", &repo.created_at, label_style, value_style));
+    lines.push(kv("Updated", &repo.updated_at, label_style, value_style));
+    if let Some(ref pushed) = repo.pushed_at {
+        lines.push(kv("Last push", pushed, label_style, value_style));
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .title(" General ")
+                .borders(Borders::ALL)
+                .border_style(theme.border_style()),
+        )
+        .wrap(Wrap { trim: false })
+        .scroll((settings.scroll as u16, 0));
+    frame.render_widget(paragraph, area);
+}
+
+fn render_branch_protections(frame: &mut Frame, state: &AppState, area: Rect) {
+    let theme = &state.theme;
+    let settings = state.settings.as_ref().unwrap();
+
+    if state.is_loading("branch_protections") {
+        let spinner = ghtui_widgets::Spinner::new(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as usize
+                / 100,
+        );
+        let paragraph = Paragraph::new(Line::from(spinner.span()))
+            .style(theme.text())
+            .block(
+                Block::default()
+                    .title(" Branch Protection Rules ")
+                    .borders(Borders::ALL)
+                    .border_style(theme.border_style()),
+            );
+        frame.render_widget(paragraph, area);
+        return;
+    }
+
+    if settings.branch_protections.is_empty() {
+        let paragraph = Paragraph::new("  No branch protection rules configured")
+            .style(theme.text_dim())
+            .block(
+                Block::default()
+                    .title(" Branch Protection Rules ")
+                    .borders(Borders::ALL)
+                    .border_style(theme.border_style()),
+            );
+        frame.render_widget(paragraph, area);
+        return;
+    }
+
+    let items: Vec<ListItem> = settings
+        .branch_protections
+        .iter()
+        .map(|bp| {
+            let mut details = Vec::new();
+
+            if let Some(ref checks) = bp.required_status_checks {
+                if checks.strict {
+                    details.push("strict");
+                }
+                if !checks.contexts.is_empty() {
+                    details.push("status checks");
+                }
+            }
+            if let Some(ref enforce) = bp.enforce_admins {
+                if enforce.enabled {
+                    details.push("enforce admins");
+                }
+            }
+            if let Some(ref reviews) = bp.required_pull_request_reviews {
+                if let Some(count) = reviews.required_approving_review_count {
+                    if count > 0 {
+                        details.push("reviews required");
+                    }
+                }
+            }
+
+            let detail_str = if details.is_empty() {
+                "basic protection".to_string()
+            } else {
+                details.join(", ")
+            };
+
+            ListItem::new(Line::from(vec![
+                Span::styled("  🔒 ", Style::default().fg(theme.warning)),
+                Span::styled(bp.pattern.clone(), theme.text_bold()),
+                Span::styled(format!("  ({})", detail_str), theme.text_dim()),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .title(format!(
+                " Branch Protection Rules ({}) ",
+                settings.branch_protections.len()
+            ))
+            .borders(Borders::ALL)
+            .border_style(theme.border_style()),
+    );
+    frame.render_widget(list, area);
+}
+
+fn render_collaborators(frame: &mut Frame, state: &AppState, area: Rect) {
+    let theme = &state.theme;
+    let settings = state.settings.as_ref().unwrap();
+
+    if state.is_loading("collaborators") {
+        let spinner = ghtui_widgets::Spinner::new(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as usize
+                / 100,
+        );
+        let paragraph = Paragraph::new(Line::from(spinner.span()))
+            .style(theme.text())
+            .block(
+                Block::default()
+                    .title(" Collaborators ")
+                    .borders(Borders::ALL)
+                    .border_style(theme.border_style()),
+            );
+        frame.render_widget(paragraph, area);
+        return;
+    }
+
+    if settings.collaborators.is_empty() {
+        let paragraph = Paragraph::new("  No collaborators found")
+            .style(theme.text_dim())
+            .block(
+                Block::default()
+                    .title(" Collaborators ")
+                    .borders(Borders::ALL)
+                    .border_style(theme.border_style()),
+            );
+        frame.render_widget(paragraph, area);
+        return;
+    }
+
+    let items: Vec<ListItem> = settings
+        .collaborators
+        .iter()
+        .map(|collab| {
+            let role = collab
+                .role_name
+                .as_deref()
+                .or_else(|| {
+                    collab.permissions.as_ref().map(|p| {
+                        if p.admin {
+                            "admin"
+                        } else if p.maintain {
+                            "maintain"
+                        } else if p.push {
+                            "write"
+                        } else if p.triage {
+                            "triage"
+                        } else {
+                            "read"
+                        }
+                    })
+                })
+                .unwrap_or("unknown");
+
+            let role_color = match role {
+                "admin" => theme.danger,
+                "maintain" => theme.warning,
+                "write" => theme.success,
+                _ => theme.fg_muted,
+            };
+
+            ListItem::new(Line::from(vec![
+                Span::styled("  @", Style::default().fg(theme.fg_muted)),
+                Span::styled(collab.login.clone(), theme.text()),
+                Span::raw("  "),
+                Span::styled(role.to_string(), Style::default().fg(role_color)),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .title(format!(
+                " Collaborators ({}) ",
+                settings.collaborators.len()
+            ))
+            .borders(Borders::ALL)
+            .border_style(theme.border_style()),
+    );
+    frame.render_widget(list, area);
+}
+
+/// Key-value line with owned strings to avoid lifetime issues.
+fn kv(label: &str, value: &str, label_style: Style, value_style: Style) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("    {:<18}", label), label_style),
+        Span::styled(value.to_string(), value_style),
+    ])
+}
+
+/// Boolean flag line.
+fn flag(label: &str, enabled: bool, theme: &ghtui_core::theme::Theme) -> Line<'static> {
+    let (icon, color) = if enabled {
+        ("✓", theme.success)
+    } else {
+        ("✗", theme.fg_muted)
+    };
+    Line::from(vec![
+        Span::styled(
+            format!("    {:<18}", label),
+            Style::default().fg(theme.fg_muted),
+        ),
+        Span::styled(icon, Style::default().fg(color)),
+    ])
+}


### PR DESCRIPTION
## Summary
- Settings 탭 뷰어 구현 (read-only)
- 3개 서브탭: General / Branch Protection / Collaborators
- Tab/Shift-Tab으로 서브탭 전환, j/k로 스크롤

## Changes
- `ghtui-core/types/settings.rs`: Repository, BranchProtection, Collaborator 타입
- `ghtui-core/state/settings.rs`: SettingsState (3 sub-tabs)
- `ghtui-api/endpoints/settings.rs`: get_repo, list_branch_protections, list_collaborators
- `ghtui/views/settings.rs`: General(정보+통계+기능), 브랜치보호, Collaborators 뷰
- ROADMAP.md 업데이트

## Test plan
- [x] `cargo clippy` 경고 0개
- [x] `cargo test` 전체 통과
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)