### PR TITLE
Remove Wiki and Projects tabs from UI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,11 +10,9 @@
 | 2 | Issues | ✅ | issue_list, issue_detail | 목록, 상세, 닫기/열기 |
 | 3 | Pull requests | ✅ | pr_list, pr_detail | 목록, 상세(Conversation/Diff/Checks), 머지, 리뷰 |
 | 4 | Actions | ✅ | actions_list, action_detail | 워크플로우 목록, 잡 목록, 로그, 취소/재실행 |
-| 5 | Projects | - | placeholder | 미구현 |
-| 6 | Wiki | - | placeholder | 미구현 |
-| 7 | Security | ✅ | security.rs | Dependabot, Code Scanning, Secret Scanning (read-only) |
-| 8 | Insights | ✅ | insights.rs | Contributors, Commit Activity, Traffic (read-only) |
-| 9 | Settings | ✅ | settings.rs | 일반설정, 브랜치 보호, Collaborators (read-only) |
+| 5 | Security | ✅ | security.rs | Dependabot, Code Scanning, Secret Scanning (read-only) |
+| 6 | Insights | ✅ | insights.rs | Contributors, Commit Activity, Traffic (read-only) |
+| 7 | Settings | ✅ | settings.rs | 일반설정, 브랜치 보호, Collaborators (read-only) |
 
 ### 완료된 기반 기능
 

--- a/crates/ghtui-core/src/router.rs
+++ b/crates/ghtui-core/src/router.rs
@@ -56,16 +56,6 @@ pub enum Route {
         job_id: u64,
     },
 
-    // Projects tab
-    Projects {
-        repo: RepoId,
-    },
-
-    // Wiki tab
-    Wiki {
-        repo: RepoId,
-    },
-
     // Security tab
     Security {
         repo: RepoId,
@@ -89,24 +79,20 @@ pub enum Route {
     },
 }
 
-/// Global tab indices matching the GitHub web layout exactly
+/// Global tab indices
 pub const TAB_CODE: usize = 0;
 pub const TAB_ISSUES: usize = 1;
 pub const TAB_PRS: usize = 2;
 pub const TAB_ACTIONS: usize = 3;
-pub const TAB_PROJECTS: usize = 4;
-pub const TAB_WIKI: usize = 5;
-pub const TAB_SECURITY: usize = 6;
-pub const TAB_INSIGHTS: usize = 7;
-pub const TAB_SETTINGS: usize = 8;
+pub const TAB_SECURITY: usize = 4;
+pub const TAB_INSIGHTS: usize = 5;
+pub const TAB_SETTINGS: usize = 6;
 
 pub const TAB_LABELS: &[&str] = &[
     "Code",
     "Issues",
     "Pull requests",
     "Actions",
-    "Projects",
-    "Wiki",
     "Security",
     "Insights",
     "Settings",
@@ -124,8 +110,6 @@ impl Route {
             Route::ActionsList { repo, .. } => format!("{} - Actions", repo),
             Route::ActionDetail { repo, run_id } => format!("{} - Run #{}", repo, run_id),
             Route::JobLog { repo, job_id, .. } => format!("{} - Job #{}", repo, job_id),
-            Route::Projects { repo } => format!("{} - Projects", repo),
-            Route::Wiki { repo } => format!("{} - Wiki", repo),
             Route::Security { repo } => format!("{} - Security", repo),
             Route::Insights { repo } => format!("{} - Insights", repo),
             Route::Settings { repo } => format!("{} - Settings", repo),
@@ -143,8 +127,6 @@ impl Route {
             Route::ActionsList { .. } | Route::ActionDetail { .. } | Route::JobLog { .. } => {
                 Some(TAB_ACTIONS)
             }
-            Route::Projects { .. } => Some(TAB_PROJECTS),
-            Route::Wiki { .. } => Some(TAB_WIKI),
             Route::Security { .. } => Some(TAB_SECURITY),
             Route::Insights { .. } => Some(TAB_INSIGHTS),
             Route::Settings { .. } => Some(TAB_SETTINGS),

--- a/crates/ghtui/src/keybindings.rs
+++ b/crates/ghtui/src/keybindings.rs
@@ -49,11 +49,9 @@ fn handle_normal_mode(key: KeyEvent, state: &AppState) -> Option<Message> {
         KeyCode::Char('2') => return Some(Message::GlobalTabSelect(1)), // Issues
         KeyCode::Char('3') => return Some(Message::GlobalTabSelect(2)), // Pull requests
         KeyCode::Char('4') => return Some(Message::GlobalTabSelect(3)), // Actions
-        KeyCode::Char('5') => return Some(Message::GlobalTabSelect(4)), // Projects
-        KeyCode::Char('6') => return Some(Message::GlobalTabSelect(5)), // Wiki
-        KeyCode::Char('7') => return Some(Message::GlobalTabSelect(6)), // Security
-        KeyCode::Char('8') => return Some(Message::GlobalTabSelect(7)), // Insights
-        KeyCode::Char('9') => return Some(Message::GlobalTabSelect(8)), // Settings
+        KeyCode::Char('5') => return Some(Message::GlobalTabSelect(4)), // Security
+        KeyCode::Char('6') => return Some(Message::GlobalTabSelect(5)), // Insights
+        KeyCode::Char('7') => return Some(Message::GlobalTabSelect(6)), // Settings
         _ => {}
     }
 

--- a/crates/ghtui/src/update/mod.rs
+++ b/crates/ghtui/src/update/mod.rs
@@ -423,8 +423,6 @@ fn handle_navigate(state: &mut AppState, route: Route) -> Vec<Command> {
             }
         }
         Route::Code { .. } => vec![],
-        Route::Projects { .. } => vec![],
-        Route::Wiki { .. } => vec![],
         Route::Security { repo } => {
             state.security = Some(SecurityState::new());
             state.loading.insert("security".to_string());
@@ -492,8 +490,6 @@ fn navigate_to_tab(state: &mut AppState) -> Vec<Command> {
             repo,
             filters: ActionsFilters::default(),
         },
-        TAB_PROJECTS => Route::Projects { repo },
-        TAB_WIKI => Route::Wiki { repo },
         TAB_SECURITY => Route::Security { repo },
         TAB_INSIGHTS => Route::Insights { repo },
         TAB_SETTINGS => Route::Settings { repo },

--- a/crates/ghtui/src/view.rs
+++ b/crates/ghtui/src/view.rs
@@ -49,20 +49,6 @@ pub fn render(frame: &mut Frame, state: &AppState, _tick: usize) {
             views::action_detail::render(frame, state, content_area)
         }
         Route::Notifications => views::notifications::render(frame, state, content_area),
-        Route::Projects { .. } => views::placeholder::render(
-            frame,
-            state,
-            content_area,
-            "Projects",
-            "Project boards and planning tools",
-        ),
-        Route::Wiki { .. } => views::placeholder::render(
-            frame,
-            state,
-            content_area,
-            "Wiki",
-            "Documentation and wiki pages",
-        ),
         Route::Security { .. } => views::security::render(frame, state, content_area),
         Route::Insights { .. } => views::insights::render(frame, state, content_area),
         Route::Settings { .. } => views::settings::render(frame, state, content_area),


### PR DESCRIPTION
## Summary
- Wiki, Projects 탭을 UI에서 제거
- 탭 번호 재배치: 1-7 (Code, Issues, PRs, Actions, Security, Insights, Settings)
- 라우터, 키바인딩, 뷰, 네비게이션에서 관련 코드 제거
- ROADMAP 업데이트

## Test plan
- [x] `cargo clippy` 경고 0개
- [x] `cargo test` 전체 통과
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)