### PR TITLE
Fix detail views not loading data from list selection

### DIFF
--- a/crates/ghtui/src/update/mod.rs
+++ b/crates/ghtui/src/update/mod.rs
@@ -271,8 +271,7 @@ pub fn update(state: &mut AppState, msg: Message) -> Vec<Command> {
                 }
                 return vec![];
             }
-            handle_list_select(state, delta);
-            vec![]
+            handle_list_select(state, delta)
         }
         Message::TabChanged(delta) => {
             let overflow = if matches!(state.route, Route::Settings { .. }) {
@@ -546,12 +545,11 @@ fn try_move_subtab(current: usize, delta: usize, count: usize) -> Option<usize> 
     }
 }
 
-fn handle_list_select(state: &mut AppState, delta: usize) {
+fn handle_list_select(state: &mut AppState, delta: usize) -> Vec<Command> {
     match &state.route {
         Route::PrList { .. } => {
             if let Some(ref mut list) = state.pr_list {
                 if delta == 0 {
-                    // Open selected
                     if let Some(pr) = list.selected_pr() {
                         let repo = state.current_repo.clone().unwrap();
                         let number = pr.number;
@@ -560,7 +558,7 @@ fn handle_list_select(state: &mut AppState, delta: usize) {
                             number,
                             tab: ghtui_core::PrTab::Conversation,
                         };
-                        state.navigate(route);
+                        return handle_navigate(state, route);
                     }
                 } else if delta == usize::MAX {
                     list.select_prev();
@@ -576,7 +574,7 @@ fn handle_list_select(state: &mut AppState, delta: usize) {
                         let repo = state.current_repo.clone().unwrap();
                         let number = issue.number;
                         let route = Route::IssueDetail { repo, number };
-                        state.navigate(route);
+                        return handle_navigate(state, route);
                     }
                 } else if delta == usize::MAX {
                     list.select_prev();
@@ -592,7 +590,7 @@ fn handle_list_select(state: &mut AppState, delta: usize) {
                         let repo = state.current_repo.clone().unwrap();
                         let run_id = run.id;
                         let route = Route::ActionDetail { repo, run_id };
-                        state.navigate(route);
+                        return handle_navigate(state, route);
                     }
                 } else if delta == usize::MAX {
                     list.select_prev();
@@ -630,6 +628,7 @@ fn handle_list_select(state: &mut AppState, delta: usize) {
         }
         _ => {}
     }
+    vec![]
 }
 
 fn refresh_current_view(state: &mut AppState) -> Vec<Command> {


### PR DESCRIPTION
## Summary
- 리스트에서 Enter로 상세 진입 시 API 데이터를 fetch하지 않던 버그 수정
- `state.navigate()` → `handle_navigate()`로 변경하여 fetch 커맨드가 발행되도록 수정
- PR Detail, Issue Detail, Action Detail 모두 영향

## Root cause
`handle_list_select`에서 `state.navigate(route)`만 호출하여 라우트만 변경되고
`handle_navigate()`를 거치지 않아 `FetchRunDetail`, `FetchPrDetail` 등의
커맨드가 생성되지 않았음

## Test plan
- [x] `cargo clippy` 경고 0개
- [x] `cargo test` 전체 통과
- [ ] Actions 리스트 → Enter → 상세 데이터 로딩 확인
- [ ] Issues 리스트 → Enter → 상세 데이터 로딩 확인
- [ ] PR 리스트 → Enter → 상세 데이터 로딩 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)