### PR TITLE
Add log scroll and mouse click support

### DIFF
--- a/crates/ghtui-core/src/message.rs
+++ b/crates/ghtui-core/src/message.rs
@@ -64,6 +64,7 @@ pub enum Message {
     // Mouse
     ScrollUp,
     ScrollDown,
+    MouseClick(u16, u16), // (column, row)
 
     // UI
     InputChanged(String),

--- a/crates/ghtui/src/app.rs
+++ b/crates/ghtui/src/app.rs
@@ -56,10 +56,13 @@ impl App {
                     match event {
                         Event::Key(key) => keybindings::handle_key(key, &self.state),
                         Event::Mouse(mouse) => {
-                            use crossterm::event::{MouseEventKind};
+                            use crossterm::event::MouseEventKind;
                             match mouse.kind {
                                 MouseEventKind::ScrollUp => Some(Message::ScrollUp),
                                 MouseEventKind::ScrollDown => Some(Message::ScrollDown),
+                                MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
+                                    Some(Message::MouseClick(mouse.column, mouse.row))
+                                }
                                 _ => None,
                             }
                         }

--- a/crates/ghtui/src/keybindings.rs
+++ b/crates/ghtui/src/keybindings.rs
@@ -141,9 +141,19 @@ fn handle_settings_keys(key: KeyEvent) -> Option<Message> {
 
 fn handle_action_detail_keys(key: KeyEvent) -> Option<Message> {
     match key.code {
+        // Job selection
         KeyCode::Char('j') | KeyCode::Down => Some(Message::ListSelect(1)),
         KeyCode::Char('k') | KeyCode::Up => Some(Message::ListSelect(usize::MAX)),
-        KeyCode::Enter => Some(Message::ListSelect(0)), // Load log for selected job
+        KeyCode::Enter => Some(Message::ListSelect(0)),
+        // Log scroll
+        KeyCode::PageDown => Some(Message::ScrollDown),
+        KeyCode::PageUp => Some(Message::ScrollUp),
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(Message::ScrollDown)
+        }
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(Message::ScrollUp)
+        }
         _ => None,
     }
 }

--- a/crates/ghtui/src/update/mod.rs
+++ b/crates/ghtui/src/update/mod.rs
@@ -249,9 +249,68 @@ pub fn update(state: &mut AppState, msg: Message) -> Vec<Command> {
             vec![]
         }
 
-        // Mouse scroll → same as j/k
-        Message::ScrollUp => update(state, Message::ListSelect(usize::MAX)),
-        Message::ScrollDown => update(state, Message::ListSelect(1)),
+        // Mouse click
+        Message::MouseClick(_col, row) => {
+            // Row 0 = repo header, Row 1 = tab bar, Row 2+ = content
+            if row == 1 {
+                // Tab bar click — compute which tab was clicked based on column position
+                // Tab labels with spacing: " N Label " format
+                let mut x: u16 = 0;
+                for (i, label) in ghtui_core::router::TAB_LABELS.iter().enumerate() {
+                    let key_width = 3u16; // " N "
+                    let label_width = label.len() as u16;
+                    let sep_width = if i < ghtui_core::router::TAB_LABELS.len() - 1 {
+                        1
+                    } else {
+                        0
+                    };
+                    let tab_end = x + key_width + label_width + sep_width;
+                    if _col >= x && _col < tab_end {
+                        state.active_tab = i;
+                        return navigate_to_tab(state);
+                    }
+                    x = tab_end;
+                }
+                vec![]
+            } else if row >= 2 {
+                // Content area click — select list item by row offset
+                let content_row = (row - 2) as usize;
+                // Find which item is at this row (accounting for border)
+                if content_row > 0 {
+                    let item_index = content_row - 1; // -1 for top border
+                    handle_mouse_list_select(state, item_index)
+                } else {
+                    vec![]
+                }
+            } else {
+                vec![]
+            }
+        }
+
+        // Scroll — context-aware
+        Message::ScrollUp => {
+            // Action Detail with log: scroll log
+            if matches!(state.route, Route::ActionDetail { .. }) {
+                if let Some(ref mut detail) = state.action_detail {
+                    if detail.log.is_some() {
+                        detail.log_scroll = detail.log_scroll.saturating_sub(3);
+                        return vec![];
+                    }
+                }
+            }
+            update(state, Message::ListSelect(usize::MAX))
+        }
+        Message::ScrollDown => {
+            if matches!(state.route, Route::ActionDetail { .. }) {
+                if let Some(ref mut detail) = state.action_detail {
+                    if detail.log.is_some() {
+                        detail.log_scroll += 3;
+                        return vec![];
+                    }
+                }
+            }
+            update(state, Message::ListSelect(1))
+        }
 
         // UI
         Message::InputChanged(text) => {
@@ -646,6 +705,41 @@ fn handle_list_select(state: &mut AppState, delta: usize) -> Vec<Command> {
                     settings.scroll = settings.scroll.saturating_sub(1);
                 } else if delta > 0 {
                     settings.scroll += 1;
+                }
+            }
+        }
+        _ => {}
+    }
+    vec![]
+}
+
+fn handle_mouse_list_select(state: &mut AppState, item_index: usize) -> Vec<Command> {
+    match &state.route {
+        Route::PrList { .. } => {
+            if let Some(ref mut list) = state.pr_list {
+                if item_index < list.items.len() {
+                    list.selected = item_index;
+                }
+            }
+        }
+        Route::IssueList { .. } => {
+            if let Some(ref mut list) = state.issue_list {
+                if item_index < list.items.len() {
+                    list.selected = item_index;
+                }
+            }
+        }
+        Route::ActionsList { .. } => {
+            if let Some(ref mut list) = state.actions_list {
+                if item_index < list.items.len() {
+                    list.selected = item_index;
+                }
+            }
+        }
+        Route::Notifications => {
+            if let Some(ref mut list) = state.notifications {
+                if item_index < list.items.len() {
+                    list.selected = item_index;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Action Detail 로그 스크롤: PageUp/PageDown, Ctrl+u/Ctrl+d
- 마우스 스크롤 시 로그가 있으면 로그 스크롤, 없으면 잡 선택
- 마우스 클릭으로 탭 바 전환
- 마우스 클릭으로 리스트 아이템 선택 (PR/Issue/Actions/Notifications)

## Test plan
- [x] `cargo clippy` 경고 0개
- [x] `cargo test` 전체 통과
- [ ] Action Detail → 잡 Enter → 로그 → PageDown/Up으로 스크롤 확인
- [ ] 탭 바 마우스 클릭 전환 확인
- [ ] 리스트 아이템 마우스 클릭 선택 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)